### PR TITLE
Proper child support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ class Counter extends Component
 
 ## Todo
 - [ ] Implement support for `key` tracking
-- [ ] Implement support for preserving child tracking
 - [ ] Moar tests.
 
 ## Testing

--- a/src/LivewireNode.php
+++ b/src/LivewireNode.php
@@ -5,39 +5,26 @@ namespace Enflow\LivewireTwig;
 use Twig\Compiler;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Node;
+use Livewire\LivewireBladeDirectives;
 
 class LivewireNode extends Node
 {
-    public function __construct(string $component, ?AbstractExpression $variables, int $lineno, string $tag = null)
+    public function __construct(string $component, AbstractExpression $variables, int $lineno, string $tag = null)
     {
-        $nodes = [];
-        if (null !== $variables) {
-            $nodes['variables'] = $variables;
-        }
-
+        $nodes = ['variables' => $variables];
         parent::__construct($nodes, ['component' => $component], $lineno, $tag);
     }
 
     public function compile(Compiler $compiler)
     {
         $component = $this->getAttribute('component');
-
-        $compiler->raw('if (! isset($_instance)) {')
-            ->outdent()
-            ->raw("\$html = \Livewire\Livewire::mount('$component', ");
-
-        if (! $this->hasNode('variables')) {
-            $compiler->raw('[]');
-        } else {
-            $compiler->raw('twig_to_array(');
-            $compiler->subcompile($this->getNode('variables'));
-            $compiler->raw(')');
-        }
-
-        $compiler->raw(")->html();\n")
-            ->indent()
-            ->raw('}');
-
-        $compiler->write('echo $html;');
+        $expr = $this->getNode('variables');
+        $compiler
+            ->write('$_instance = $context["_instance"] ?? null;', "\n")
+            ->write('$_vars = ')->subcompile($expr)->raw(";\n")
+            ->write("?>\n")
+            ->write(LivewireBladeDirectives::livewire("'$component', \$_vars"))
+            ->write("<?php\n")
+          ;
     }
 }

--- a/src/LivewireTokenParser.php
+++ b/src/LivewireTokenParser.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Twig\Error\SyntaxError;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
+use Twig\Node\Expression\ArrayExpression;
 
 class LivewireTokenParser extends AbstractTokenParser
 {
@@ -29,9 +30,10 @@ class LivewireTokenParser extends AbstractTokenParser
             );
         }
 
-        $variables = null;
         if ($this->parser->getStream()->nextIf(/* Token::NAME_TYPE */ 5, 'with')) {
             $variables = $this->parser->getExpressionParser()->parseExpression();
+        } else {
+            $variables = new ArrayExpression([], $token->getLine());
         }
 
         $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);

--- a/tests/NestedTest.php
+++ b/tests/NestedTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Enflow\LivewireTwig\Test;
+
+use Livewire\Component;
+use Livewire\Livewire;
+
+class NestedTest extends TestCase
+{
+    public function test_nested_component_renders_only_once()
+    {
+        Livewire::component('childcounter', Child::class);
+
+        $nested = Livewire::test(NestedChilds::class);
+        $nested->assertSeeLivewire('childcounter');
+        $nested->call('increment');   // should not call render() in Child, renderedCound should remain 1
+        $this->assertLessThan(2, Child::$renderedCount, 'Child component rendered more than once');
+    }
+}
+
+class NestedChilds extends Component
+{
+    public $elements;
+    public $counter = 0;
+
+    public function increment()
+    {
+      $this->counter++;
+    }
+    public function render()
+    {
+        return view('components.haschilds');
+    }
+}
+
+class Child extends Component
+{
+    static $renderedCount = 0;
+    public $count = 1;
+
+    public function incrementChild()
+    {
+      $this->count++;
+    }
+    public function render()
+    {
+        static::$renderedCount++;
+        $this->count = static::$renderedCount;
+        return view('components.counter');
+    }
+}

--- a/tests/views/components/haschilds.twig
+++ b/tests/views/components/haschilds.twig
@@ -1,0 +1,6 @@
+<div>
+    {{ counter }}
+    <div class="child">
+        {% livewire 'childcounter' with { 'count': 1, 'title': 'Child' } %}
+    </div>
+</div>


### PR DESCRIPTION
This is the request which I would create an which adds the nested child support. It includes a test which uses a side effect of this support: a child is not re-rendered if only the parent state changes. The Livewire test support does not emulate the JavaScript-environment of the real environment, which saves the existing child in this case.
Nonetheless, the test fails on the original code and succeeds on this version.
It would not be too difficult to add key-tracking as well, but I haven´t found a situation where it is needed. Maybe I should look harder...
